### PR TITLE
add arrow noth-east on Docs header link

### DIFF
--- a/components/PmndrsHeader.tsx
+++ b/components/PmndrsHeader.tsx
@@ -111,6 +111,7 @@ const PmndrsHeader = () => {
               sm:block"
                 >
                   {link.title}
+                  {link.title === 'Docs' && <sup className="text-xs">{' ↗'}</sup>}
                 </Link>
               ))}
             <SearchButton />


### PR DESCRIPTION
Gives a visual cue that the Docs are in an external address.  Not sure if adding this cue to every external link is relevant.